### PR TITLE
fix: cannot convert 'YGValue' to 'double' without a conversion operator

### DIFF
--- a/cpp/nodeProperties.h
+++ b/cpp/nodeProperties.h
@@ -538,7 +538,7 @@ namespace nodeProperties
 
         INSTALL_HOST_FUN(getGap, 1, {
             auto gap = YGNodeStyleGetGap(node, static_cast<YGGutter>(arguments[0].getNumber()));
-            return Value(static_cast<double>(gap));
+            SET_YGVALUE(gap);
         });
 
         INSTALL_HOST_FUN(setDirtiedFunc, 1, {


### PR DESCRIPTION
getGap() should return a {value, unit} object and currently fails to compile with 
```
cannot convert 'YGValue' to 'double' without a conversion operator
```

I've fixed it by using SET_YGVALUE(...) instead